### PR TITLE
Add galaxy role implementation for Docker ECR integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# ansible-role-docker-ecr
+Ansible Role: Docker ECR Authentication
+=======================================
+
+An [Ansible Galaxy](https://galaxy.ansible.com/) role for configuring Docker for authentication with Amazon Elastic Container Registry.
+
+Role Variables
+--------------
+
+The following variables should be defined in any project that uses this role:
+
+| Variable          | Default | Description                                                            |
+|-------------------|---------|------------------------------------------------------------------------|
+| `docker_ecr_user` | *None*  | The username for the system account that will be using ECR with Docker |
+
+In addition, an `ecr_environment` dictionary variable should be defined, comprising the following AWS access credentials:
+
+| Variable                | Default | Description                                                          |
+|-------------------------|---------|----------------------------------------------------------------------|
+| `aws_registry_host`     | *None*  | The AWS ECR host (e.g. `1234567890.dkr.ecr.eu-west-1.amazonaws.com`) |
+| `aws_access_key_id`     | *None*  | The AWS access key ID                                                |
+| `aws_secret_access_key` | *None*  | The AWS secret access key                                            |
+| `aws_default_region`    | *None*  | The AWS region (e.g. `eu-west-1`)                                    |
+
+For example:
+
+```
+docker_ecr_user: ecr-user
+
+ecr_environment:
+  aws_registry_host: 1234567890.dkr.ecr.eu-west-1.amazonaws.com
+  aws_access_key_id: AAAABBBBCCCCDDDD1111
+  aws_secret_access_key: abcdefghijklmnopqrstuvwxyz1234567890!@£ 
+  aws_default_region: eu-west-1
+```
+
+Example Requirements File
+-------------------------
+
+```
+- src: https://github.com/companieshouse/ansible-role-docker-ecr
+  name: docker-ecr
+```
+
+License
+-------
+
+MIT
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+ecr_credential_binary: /bin/docker-credential-ecr-login
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,14 @@
+galaxy_info:
+  author: Companies House
+  description: Configure Docker for authentication with Amazon Elastic Container Registry
+  license: MIT
+
+  min_ansible_version: 2.7.9
+
+  platforms:
+    - name: centos
+      versions:
+        - 7
+
+dependencies: []
+

--- a/tasks/configure-docker-user.yml
+++ b/tasks/configure-docker-user.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Debug print user
+  debug:
+    msg: "Configuring docker for: {{ item }}"
+
+- name: Configure users bash profile
+  template:
+    src:   bash_profile.j2
+    dest:  /home/{{ item }}/.bash_profile
+    owner: "{{ item }}"
+    mode:  0644
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+
+- name: Install Golang
+  yum:
+    name: golang-1.11.5-1.el7
+    state: present
+
+- name: Add go path for users
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/profile.d/{{ item }}"
+    mode: 0555
+  with_items:
+    - go-path.sh
+
+- name: Configure Docker users
+  include_tasks: configure-docker-user.yml
+  with_items: "{{ docker_ecr_user }}"
+
+- name: go get docker-ecr-credential-login repo
+  command:
+    go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+  args:
+    creates: "{{ ecr_credential_binary }}"
+
+- name: Copy docker-credential-ecr-login
+  command: cp /root/go/bin/docker-credential-ecr-login /bin
+
+- name: Creating /home/{{ docker_ecr_user }}/.docker directory
+  become_user: "{{ docker_ecr_user }}"
+  become: yes
+  file:
+    mode: 0755
+    path: "/home/{{ docker_ecr_user }}/.docker"
+    state: directory
+
+- name: Template Docker authentication configuration
+  become_user: "{{ docker_ecr_user }}"
+  become: yes
+  template:
+    src: "{{ item }}.j2"
+    dest: "/home/{{ docker_ecr_user }}/.docker/{{ item }}"
+    mode: 0755
+  with_items:
+    - config.json
+

--- a/templates/bash_profile.j2
+++ b/templates/bash_profile.j2
@@ -1,0 +1,15 @@
+# .bash_profile
+
+# Get the aliases and functions
+if [ -f ~/.bashrc ]; then
+        . ~/.bashrc
+fi
+
+# User specific environment and startup programs
+
+PATH=$PATH:$HOME/.local/bin:$HOME/bin
+
+export AWS_DEFAULT_REGION={{ ecr_environment.aws_default_region }}
+export AWS_ACCESS_KEY_ID={{ ecr_environment.aws_access_key_id }}
+export AWS_SECRET_ACCESS_KEY={{ ecr_environment.aws_secret_access_key }}
+

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -1,0 +1,7 @@
+{
+  "credsStore": "ecr-login",
+  "credHelpers": {
+    "{{ ecr_environment.aws_registry_host }}": "ecr-login"
+  }
+}
+

--- a/templates/go-path.sh.j2
+++ b/templates/go-path.sh.j2
@@ -1,0 +1,3 @@
+export GOPATH=$HOME/go
+export PATH=${GOPATH}/bin:$PATH
+


### PR DESCRIPTION
These changes introduce an Ansible Galaxy role for configuring a Docker client for authentication with Amazon Elastic Container Registry.

Resolves: DVOP-410