### PR TITLE
Ensure correct SSH user is used when checking golang installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check for Golang installation
-  shell: runuser -l 'ec2-user' -c "command -v go 2>/dev/null"
+  shell: runuser -l '{{ ansible_ssh_user }}' -c "command -v go 2>/dev/null"
   register: golang_install
   ignore_errors: yes
 


### PR DESCRIPTION
The 'Check for Golang installation' task will fail when run against hosts that do not have an `ec2-user` account. This change ensures that the correct user is used dependent on the context in which this role is run.