### PR TITLE
Fix for permissions issue with symbolic link

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,13 +35,14 @@
   args:
     creates: /root/go/bin/docker-credential-ecr-login
 
-- name: Create symbolic link for Docker ECR credential helper
-  file:
+- name: Install system-wide Docker ECR credential helper
+  copy:
     src: /root/go/bin/docker-credential-ecr-login
     dest: "{{ ecr_credential_binary }}"
     owner: root
     group: root
-    state: link
+    mode: '0755'
+    remote_src: yes
 
 - name: Configure user account(s) for Docker ECR authentication
   include_tasks: user.yml


### PR DESCRIPTION
This change introduces a fix whereby the symbolic link to the Docker ECR credential helper references a binary contained in a directory with restrictive permissions for other users.