### PR TITLE
Replace ansible_ssh_user -> ansible_user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check for Golang installation
-  shell: runuser -l '{{ ansible_ssh_user }}' -c "command -v go 2>/dev/null"
+  shell: runuser -l '{{ ansible_user }}' -c "command -v go 2>/dev/null"
   register: golang_install
   ignore_errors: yes
 


### PR DESCRIPTION
This change is used to target the same user we declare within our AMI builds. 

Note: Only one repo current uses this role and uses the current version tag